### PR TITLE
Adds appropriate types to `courses.service.ts`

### DIFF
--- a/src/app/courses/services/courses.service.ts
+++ b/src/app/courses/services/courses.service.ts
@@ -27,8 +27,8 @@ export class CoursesService {
     }
 
 
-    saveCourse(courseId:number, changes: Partial<Course>) {
-        return this.http.put(`/api/courses/${courseId}`, changes);
+    saveCourse(courseId:number, changes: Partial<Course>): Observable<Course> {
+        return this.http.put<Course>(`/api/courses/${courseId}`, changes);
     }
 
     findLessons(


### PR DESCRIPTION
The course is missing the correct types for the `saveCourse` method so that tests were unable to run properly. Looks like this is fixed on the master branch but is not implemented in the 1-start branch.

Changes:

- Adds correct type information to saveCourse method in `course.service.ts`