### PR TITLE
Update karma.conf.js with missing plugin

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -7,6 +7,7 @@ module.exports = function (config) {
     frameworks: ['jasmine', '@angular-devkit/build-angular'],
     plugins: [
       require('karma-jasmine'),
+      require("karma-coverage"),
       require('karma-chrome-launcher'),
       require('karma-jasmine-html-reporter'),
       require('karma-coverage-istanbul-reporter'),


### PR DESCRIPTION
Missing plugin added. Otherwise error thrown when generating code coverage. 
Error thrown when running "ng test --watch=false --codeCoverage".
Error message ":ERROR [reporter]: Can not load reporter "coverage", it is not registered! Perhaps you are missing some plugin?".

